### PR TITLE
issue #28

### DIFF
--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -64,6 +64,7 @@ class BasesfMelodyActions extends sfMelodyBaseActions
         $user = $melody->getUser();
         if($redirect_register)
         {
+          $this->getUser()->setAttribute('access_token', serialize($access_token));
           $this->getUser()->setAttribute('melody_user', serialize($user));
           $this->getUser()->setAttribute('melody', serialize($melody));
 


### PR DESCRIPTION
Simple patch to pass even access_token to register_redirect, otherwise you can't save token from the redirect_register action.
