### PR TITLE
fix unlimited expiration for linkedIn

### DIFF
--- a/lib/melody/sfLinkedinMelody.class.php
+++ b/lib/melody/sfLinkedinMelody.class.php
@@ -12,9 +12,17 @@ class sfLinkedinMelody extends sfMelody1
     $this->setNamespace('default', 'https://api.linkedin.com/v1');
     $this->setAlias('me', 'people/~');
   }
-
+    /*
+    * if expiration = 0 then it means that the expiration limit is unlimited
+     * -> the default is to never expire.
+    */
   protected function setExpire(&$token)
   {
-    $token->setExpire(time() + $token->getParam('oauth_authorization_expires_in'));
+    if($token->getParam('oauth_authorization_expires_in') == 0){
+        $token->setExpire(null);
+    }
+    else{
+        $token->setExpire(time() + $token->getParam('oauth_authorization_expires_in'));
+    }
   }
 }


### PR DESCRIPTION
Since the default is to never expire with LinkedIn, which is returned through the API by 0, it needed an interpretation of this.

otherwise the isConnected method will never return true, because the expiration is time() + 0.
