### PR TITLE
Support for Facebook's display parameter

### DIFF
--- a/lib/melody/sfFacebookMelody.class.php
+++ b/lib/melody/sfFacebookMelody.class.php
@@ -15,6 +15,11 @@ class sfFacebookMelody extends sfMelody2
     {
       $this->setAuthParameter('scope', implode(',', $config['scope']));
     }
+
+    if(isset($config['display']))
+    {
+      $this->setAuthParameter('display', $config['display']);
+    }
   }
 
   public function fql($query)


### PR DESCRIPTION
As per issue #23, here is a fix to be able to use the display parameter.

For touch units you can configure is as follows:

``` yaml
all:
  melody:
    facebook:
      display: touch
```

Of course you can override it for certain actions:
`$this->getUser()->connect('facebook', array('config' => 'wap'));`
