### PR TITLE
sfMelodyPlugin and sfGuardUserProfile

### DIFF
--- a/lib/melody/sfFacebookMelody.class.php
+++ b/lib/melody/sfFacebookMelody.class.php
@@ -50,4 +50,14 @@ class sfFacebookMelody extends sfMelody2
       $token->setExpire(time() + $token->getParam('expires'));
     }
   }
+
+	protected function getExpire($token)
+	{
+		if($token->getParam('expires'))
+		{
+			return time() + $token->getParam('expires');
+		}
+
+		return null;
+	}
 }

--- a/lib/orm/sfMelodyPropelOrmAdapter.class.php
+++ b/lib/orm/sfMelodyPropelOrmAdapter.class.php
@@ -36,6 +36,10 @@ class sfMelodyPropelOrmAdapter extends sfMelodyOrmAdapter
       }
     }
 
+	$map = $c->getMap();
+	if (empty($map))
+		throw new OAuthException('Cannot retrieve information for user', 1000);
+
     return sfGuardUserPeer::doSelectOne($c);
   }
 }

--- a/lib/user/sfMelodyUserFactory.class.php
+++ b/lib/user/sfMelodyUserFactory.class.php
@@ -107,7 +107,7 @@ class sfMelodyUserFactory
       $user->save();
     }
 	  
-	if($user_profile_modified)
+	if(isset($user_profile))
 	{
 		$user->setSfGuardUserProfile($user_profile);
 	}

--- a/lib/user/sfMelodyUserFactory.class.php
+++ b/lib/user/sfMelodyUserFactory.class.php
@@ -47,10 +47,19 @@ class sfMelodyUserFactory
     //$user_class = sfConfig::get('app_melody_user_class', 'sfGuardUser');
 
     $user = new sfGuardUser();
+	if(sfConfig::get('app_melody_use_profile', 'false') && sfConfig::get('app_sf_guard_plugin_profile_class', ''))
+	{
+		$user_profile_classname = sfConfig::get('app_sf_guard_plugin_profile_class', '');
+		if($user_profile_classname)
+		{
+			$user_profile = new $user_profile_classname;
+		}
+	}
 
     $config = $this->getConfig();
 
     $modified = false;
+	$user_profile_modified = false;
 
     $last_call = null;
     $last_result = null;
@@ -84,6 +93,11 @@ class sfMelodyUserFactory
             $user->$method($result);
             $modified = true;
           }
+		  elseif(isset($user_profile) && is_callable(array($user_profile, $method)) && method_exists($user_profile, $method))
+		  {
+			  $user_profile->$method($result);
+			  $user_profile_modified = true;
+		  }
         }
       }
     }
@@ -92,6 +106,11 @@ class sfMelodyUserFactory
     {
       $user->save();
     }
+	  
+	if($user_profile_modified)
+	{
+		$user->setSfGuardUserProfile($user_profile);
+	}
 
     return $user;
   }

--- a/lib/user/sfMelodyUserFactory.class.php
+++ b/lib/user/sfMelodyUserFactory.class.php
@@ -59,7 +59,6 @@ class sfMelodyUserFactory
     $config = $this->getConfig();
 
     $modified = false;
-	$user_profile_modified = false;
 
     $last_call = null;
     $last_result = null;
@@ -96,21 +95,20 @@ class sfMelodyUserFactory
 		  elseif(isset($user_profile) && is_callable(array($user_profile, $method)) && method_exists($user_profile, $method))
 		  {
 			  $user_profile->$method($result);
-			  $user_profile_modified = true;
 		  }
         }
       }
     }
 
+	if(isset($user_profile))
+	{
+		$user_profile->setSfGuardUser($user);
+	}
+
     if($save)
     {
       $user->save();
     }
-	  
-	if(isset($user_profile))
-	{
-		$user->setSfGuardUserProfile($user_profile);
-	}
 
     return $user;
   }

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -21,7 +21,12 @@ class BasesfMelodyActions extends sfMelodyBaseActions
     $melody = $this->getMelody();
 
     $melody->setCallback('@melody_access?service='.$melody->getName());
-    $access_token = $melody->getAccessToken($this->getCode());
+	$parameters = array();
+	if($request->getParameter('redirect_uri'))
+	{
+		$parameters['redirect_uri'] = $request->getParameter('redirect_uri');
+	}
+    $access_token = $melody->getAccessToken($this->getCode(), $parameters);
 
     $melody->setToken($access_token);
 

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -62,8 +62,11 @@ class BasesfMelodyActions extends sfMelodyBaseActions
       if(!$user && ( $create_user || $redirect_register))
       {
         $user = $melody->getUser();
+
         if($redirect_register)
         {
+		  //Bad workflow
+		  $this->getUser()->setAttribute('melody_user_profile', serialize($user->getSfGuardUserProfile()));
           $this->getUser()->setAttribute('melody_user', serialize($user));
           $this->getUser()->setAttribute('melody', serialize($melody));
 

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -92,7 +92,7 @@ class BasesfMelodyActions extends sfMelodyBaseActions
     $this->getUser()->addToken($access_token);
 
 
-	if($this->getUser()->hasAttribute('auth_redirect_url'))
+	if($this->getUser()->getAttribute('auth_redirect_url'))
 	{
 		$redirect_url = $this->getUser()->getAttribute('auth_redirect_url');
 		$this->getUser()->getAttributeHolder()->remove('auth_redirect_url');

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -91,15 +91,6 @@ class BasesfMelodyActions extends sfMelodyBaseActions
 
     $this->getUser()->addToken($access_token);
 
-
-	if($this->getUser()->getAttribute('auth_redirect_url'))
-	{
-		$redirect_url = $this->getUser()->getAttribute('auth_redirect_url');
-		$this->getUser()->getAttributeHolder()->remove('auth_redirect_url');
-		$this->redirect($redirect_url);
-		return sfView::NONE;
-	}
-
     $this->redirect($this->getCallback());
   }
 }

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -91,8 +91,14 @@ class BasesfMelodyActions extends sfMelodyBaseActions
 
     $this->getUser()->addToken($access_token);
 
-	if ($this->getUser()->getAttribute('auth_redirect_url'))
-		  $this->redirect($this->getUser()->getAttribute('auth_redirect_url'));
+
+	if($this->getUser()->hasAttribute('auth_redirect_url'))
+	{
+		$redirect_url = $this->getUser()->getAttribute('auth_redirect_url');
+		$this->getUser()->getAttributeHolder()->remove('auth_redirect_url');
+		$this->redirect($redirect_url);
+		return sfView::NONE;
+	}
 
     $this->redirect($this->getCallback());
   }

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -91,6 +91,9 @@ class BasesfMelodyActions extends sfMelodyBaseActions
 
     $this->getUser()->addToken($access_token);
 
+	if ($request->getReferer())
+		$this->redirect($request->getReferer());
+
     $this->redirect($this->getCallback());
   }
 }

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -91,8 +91,8 @@ class BasesfMelodyActions extends sfMelodyBaseActions
 
     $this->getUser()->addToken($access_token);
 
-	if ($request->getReferer())
-		$this->redirect($request->getReferer());
+	if ($this->getUser()->getAttribute('auth_redirect_url'))
+		  $this->redirect($this->getUser()->getAttribute('auth_redirect_url'));
 
     $this->redirect($this->getCallback());
   }

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -72,10 +72,19 @@ class BasesfMelodyActions extends sfMelodyBaseActions
 
           $this->redirect($redirect_register);
         }
-        else
+        elseif($user)
         {
           $user->save();
         }
+		elseif(sfConfig::get('app_melody_oauth_fail', false))
+		{
+			$this->getUser()->setAttribute('error_info', $access_token->getResponseInfo());
+			$this->redirect(sfConfig::get('app_melody_oauth_fail', false));
+		}
+		else
+		{
+			$this->forward404();
+		}
       }
     }
 
@@ -88,6 +97,15 @@ class BasesfMelodyActions extends sfMelodyBaseActions
         $this->getUser()->signin($user, sfConfig::get('app_melody_remember_user', true));
       }
     }
+	elseif(sfConfig::get('app_melody_oauth_fail', false))
+	{
+		$this->getUser()->setAttribute('error_info', $access_token->getResponseInfo());
+		$this->redirect(sfConfig::get('app_melody_oauth_fail', false));
+	}
+	else
+	{
+		$this->forward404();
+	}
 
     $this->getUser()->addToken($access_token);
 

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -44,7 +44,8 @@ class BasesfMelodyActions extends sfMelodyBaseActions
 	//Емана!! 0ЩO
     elseif($access_token->getTokenKey())
     {
-      $old_token = $this->getOrmAdapter('Token')->findOneByNameAndIdentifier($melody->getName(), $melody->getIdentifier(), $access_token->getExpire());
+//      $old_token = $this->getOrmAdapter('Token')->findOneByNameAndIdentifier($melody->getName(), $melody->getIdentifier(), $access_token->getExpire());
+		$old_token = TokenPeer::findOneByNameAndIdentifier($melody->getName(), $melody->getIdentifier(), $access_token->getExpire());
 
       //try to get user from the token
       if($old_token)

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -44,7 +44,7 @@ class BasesfMelodyActions extends sfMelodyBaseActions
 	//Емана!! 0ЩO
     elseif($access_token->getTokenKey())
     {
-      $old_token = $this->getOrmAdapter('Token')->findOneByNameAndIdentifier($melody->getName(), $melody->getIdentifier());
+      $old_token = $this->getOrmAdapter('Token')->findOneByNameAndIdentifier($melody->getName(), $melody->getIdentifier(), $access_token->getExpire());
 
       //try to get user from the token
       if($old_token)

--- a/modules/sfMelody/lib/BasesfMelodyActions.class.php
+++ b/modules/sfMelody/lib/BasesfMelodyActions.class.php
@@ -36,7 +36,8 @@ class BasesfMelodyActions extends sfMelodyBaseActions
       $dispatcher = $this->getContext()->getEventDispatcher();
       $user = $dispatcher->filter($event, $user)->getReturnValue();
     }
-    else
+	//Емана!! 0ЩO
+    elseif($access_token->getTokenKey())
     {
       $old_token = $this->getOrmAdapter('Token')->findOneByNameAndIdentifier($melody->getName(), $melody->getIdentifier());
 
@@ -86,17 +87,18 @@ class BasesfMelodyActions extends sfMelodyBaseActions
 			$this->forward404();
 		}
       }
-    }
 
-    if($user)
-    {
-      $access_token->setUserId($user->getId());
 
-      if(!$this->getUser()->isAuthenticated() && $user->getIsActive())
-      {
-        $this->getUser()->signin($user, sfConfig::get('app_melody_remember_user', true));
-      }
-    }
+		if($user)
+		{
+		  $access_token->setUserId($user->getId());
+
+		  if(!$this->getUser()->isAuthenticated() && $user->getIsActive())
+		  {
+			$this->getUser()->signin($user, sfConfig::get('app_melody_remember_user', true));
+		  }
+		}
+	}
 	elseif(sfConfig::get('app_melody_oauth_fail', false))
 	{
 		$this->getUser()->setAttribute('error_info', $access_token->getResponseInfo());


### PR DESCRIPTION
Look at this http://forum.symfony-project.org/viewtopic.php?f=12&t=33956
I have same trouble. In propel version of sfGuardPlugin, there aren't such fields as first_name or email_adress.
Normally i use sf_guard_user_profile table for such data:

App.yml:

<pre>
all:
  sf_guard_plugin:
   profile_class:      sfGuardUserProfile
   profile_field_name: sf_guard_user_id
</pre>


But sfMelodyPlugin not work with the profile, plugin try to use setters of sfGuardUser object only. There is some patch of that problem. Some key in app.yml explains to sfMelody to look for profile setters if it cant't find in sfGuardUser.

For example, my app.yml.

<pre>
all:
  sf_guard_plugin:
   profile_class:      sfGuardUserProfile
   profile_field_name: sf_guard_user_id
  melody:
    use_profile: true
.....
        first_name:
          call: me
          path: first_name
        last_name:
          call: me
          path: last_name
        nick:
          call: me
          path: username
        ext_id:
          call: me
          path: id
        ext_link:
          call: me
          path: link
</pre>


After registration i get 2 new tuples in DB:

<pre>
select * from sf_guard_user;
 id |      username       | algorithm |     created_at      |     last_login      | is_active | is_super_admin |       email       
----+---------------------+-----------+---------------------+---------------------+-----------+----------------+-------------------
 19 | Facebook_1464279882 | sha1      | 2012-02-08 13:15:14 | 2012-02-08 13:15:14 | t         | f              | madesst@gmail.com
(1 row)

select * from sf_guard_user_profile;
 sf_guard_user_id | first_name | last_name |  nick   |   ext_id   |            ext_link             
------------------+------------+-----------+---------+------------+---------------------------------
               19 | Maksim     | Ustinov   | madesst | 1464279882 | http://www.facebook.com/madesst
(1 row)
</pre>


Code is very stupid, but it works for now.
I hope this will be useful.
