### PR TITLE
Added authentication with google and namespace support for sfMelodyUserFactory::createUser

### DIFF
--- a/lib/melody/sfGoogleMelody.class.php
+++ b/lib/melody/sfGoogleMelody.class.php
@@ -48,6 +48,20 @@ class sfGoogleMelody extends sfMelody1
 
     $this->init($config, 'api', 'use');
   }
+  
+  public function getIdentifier()
+  {
+     $prevNs = $this->getCurrentNamespace();  
+     if ($data = $this->ns('plus')->get('people/me')) {
+         $return = $data->id;
+     } elseif ($data = $this->ns('userinfo')->get('email')) {
+         $return = $data->data->email;
+     } else {
+         $return = null;
+     }
+     $this->ns($prevNs);
+     return $return;
+  }
 
   public function useApi($api)
   {

--- a/lib/melody/sfGoogleMelody.class.php
+++ b/lib/melody/sfGoogleMelody.class.php
@@ -19,6 +19,7 @@ class sfGoogleMelody extends sfMelody1
                                   'open_social' => 'http://www-opensocial.googleusercontent.com/api/people',
                                   'orkut' => 'http://www.orkut.com/social/rest',
                                   'picasa' => 'http://picasaweb.google.com/data',
+                                  'plus' => 'https://www.googleapis.com/plus/v1',
                                   'sidewiki' => 'http://www.google.com/sidewiki/feeds',
                                   'sites' => 'http://sites.google.com/feeds',
                                   'spreadsheets' => 'http://spreadsheets.google.com/feeds',
@@ -38,7 +39,7 @@ class sfGoogleMelody extends sfMelody1
     $this->addNamespaces(self::$apis);
     $this->setCallParameter('alt', 'json');
     $this->setAlias('contacts', 'm8/feeds/contacts');
-    $this->setAlias('me', 'default/full');
+    //$this->setAlias('me', 'default/full');
 
     if(isset($config['scope']))
     {

--- a/lib/melody/sfGoogleMelody.class.php
+++ b/lib/melody/sfGoogleMelody.class.php
@@ -22,6 +22,7 @@ class sfGoogleMelody extends sfMelody1
                                   'sidewiki' => 'http://www.google.com/sidewiki/feeds',
                                   'sites' => 'http://sites.google.com/feeds',
                                   'spreadsheets' => 'http://spreadsheets.google.com/feeds',
+                                  'userinfo' => 'https://www.googleapis.com/userinfo',
                                   'wave' => 'http://wave.googleusercontent.com/api/rpc',
                                   'webmaster_tools' => 'http://www.google.com/webmasters/tools/feeds',
                                   'youtube' => 'http://gdata.youtube.com'

--- a/lib/melody/sfGoogleMelody.class.php
+++ b/lib/melody/sfGoogleMelody.class.php
@@ -24,6 +24,7 @@ class sfGoogleMelody extends sfMelody1
                                   'sites' => 'http://sites.google.com/feeds',
                                   'spreadsheets' => 'http://spreadsheets.google.com/feeds',
                                   'userinfo' => 'https://www.googleapis.com/userinfo',
+                                  'oauth2' => 'https://www.googleapis.com/oauth2/v1',
                                   'wave' => 'http://wave.googleusercontent.com/api/rpc',
                                   'webmaster_tools' => 'http://www.google.com/webmasters/tools/feeds',
                                   'youtube' => 'http://gdata.youtube.com'
@@ -52,10 +53,8 @@ class sfGoogleMelody extends sfMelody1
   public function getIdentifier()
   {
      $prevNs = $this->getCurrentNamespace();  
-     if ($data = $this->ns('plus')->get('people/me')) {
+     if ($data = $this->ns('oauth2')->get('userinfo')) {
          $return = $data->id;
-     } elseif ($data = $this->ns('userinfo')->get('email')) {
-         $return = $data->data->email;
      } else {
          $return = null;
      }

--- a/lib/user/sfMelodyUserFactory.class.php
+++ b/lib/user/sfMelodyUserFactory.class.php
@@ -112,7 +112,7 @@ class sfMelodyUserFactory
       $path = isset($config['path'])?$config['path']:null;
       $prefix = isset($config['prefix'])?$config['prefix']:null;
       $suffix = isset($config['suffix'])?$config['suffix']:null;
-      $ns = isset($config['namespace'])?$config['namespace']:null;
+      $ns = isset($config['namespace'])?$config['namespace']:'default';
     }
     else
     {

--- a/lib/user/sfMelodyUserFactory.class.php
+++ b/lib/user/sfMelodyUserFactory.class.php
@@ -56,7 +56,7 @@ class sfMelodyUserFactory
     $last_result = null;
     foreach($config as $field => $field_config)
     {
-      list($call, $call_parameters, $path, $prefix, $suffix) = $this->explodeConfig($field_config);
+      list($call, $call_parameters, $path, $prefix, $suffix, $ns) = $this->explodeConfig($field_config);
 
       if(!is_null($call))
       {
@@ -66,7 +66,7 @@ class sfMelodyUserFactory
         }
         else
         {
-          $result = $this->getService()->get($call, $call_parameters);
+          $result = $this->getService()->ns($ns)->get($call, $call_parameters);
           $last_result = $result;
           $last_call = $call;
         }
@@ -103,6 +103,7 @@ class sfMelodyUserFactory
     $path = '';
     $prefix = '';
     $suffix = '';
+    $ns = 'default';
 
     if(is_array($config))
     {
@@ -111,13 +112,14 @@ class sfMelodyUserFactory
       $path = isset($config['path'])?$config['path']:null;
       $prefix = isset($config['prefix'])?$config['prefix']:null;
       $suffix = isset($config['suffix'])?$config['suffix']:null;
+      $ns = isset($config['namespace'])?$config['namespace']:null;
     }
     else
     {
       $call = $config;
     }
 
-    return array($call, $call_parameters, $path, $prefix, $suffix);
+    return array($call, $call_parameters, $path, $prefix, $suffix, $ns);
   }
 
   public function getKeys()


### PR DESCRIPTION
There was no useful way to get basic user info for google accounts, so a added some changes:

a new "userinfo" namespace in the google class: https://www.googleapis.com/userinfo
the required scope is "https://www.googleapis.com/auth/userinfo.email", so this does not work with the api config (for whatever reason, scope is different to namespace)

As this is not the default namespace, i added  a parameter "namespace" to use with the user configuration.

So, to authenticate with google and retrieve the email, use this config:

```
  melody:
    ...

    google:
      key:  ...
      secret: ...
      callback: "@homepage"   # or absolute url

      # api: []  DOES NOT WORK      # only for google - easy way to set scopes
      scope: [https://www.googleapis.com/auth/userinfo.email]

      user:                       # to create an user
        email:
          call: email
          path: data.email
          key: true
          namespace: userinfo # use the namespace userinfo for the email-call, not the default one
```
