### PR TITLE
Remove all Melody related user attributes on sign out

### DIFF
--- a/lib/user/sfMelodyUser.class.php
+++ b/lib/user/sfMelodyUser.class.php
@@ -58,6 +58,8 @@ class sfMelodyUser extends sfGuardSecurityUser
   public function signOut()
   {
     $this->getAttributeHolder()->removeNamespace('Melody');
+    $this->getAttributeHolder()->remove('melody');
+    $this->getAttributeHolder()->remove('melody_user');
     parent::signOut();
   }
 


### PR DESCRIPTION
Some melody user attributes remains when the user signs out.
